### PR TITLE
thriftpy2 0.5.3 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,35 +1,39 @@
 {% set name = "thriftpy2" %}
-{% set version = "0.4.20" %}
+{% set version = "0.5.3" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 8d2ffc5a9a3e3b239418726f83572512240c13adaa135701996749c81a75c2c5
+  url: https://github.com/Thriftpy/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: 16f3fd24f7778416d70b7cbd2cefce28e49ba72abe9f12471ae7697b09c70c25
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
+  skip: true  # [py<37]
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('c') }}
   host:
     - pip
     - python
-    - setuptools
     - wheel
+    - setuptools >=68
+    - toml
     - cython >=0.28.4,<4
   run:
-    - ply >=3.4,<4.0
     - python
-    - six >=1.15,<2.dev0
+    - ply >=3.4,<4.0
+    - six >=1.15,<2
 
 test:
-  requires:
-    - pip
+  source_files:
+    - tests
+    - examples
   imports:
     - thriftpy2
     - thriftpy2.parser
@@ -37,9 +41,14 @@ test:
     - thriftpy2.transport
   commands:
     - pip check
+    - cd tests && pytest test_base.py
+  requires:
+    - pip
+    - pytest >=6.1.1,<8.2.0
+    - pytest-asyncio
 
 about:
-  home: https://thriftpy2.readthedocs.io/
+  home: https://thriftpy2.readthedocs.io
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -54,8 +63,8 @@ about:
     ThriftPy2 helps that, it's compatible with Apache Thrift so you no longer need to install 'thrift' 
     package, it can import thrift file on the fly so you no longer need to re-generate the sdk again 
     and again and again.
-  doc_url: https://thriftpy2.readthedocs.io/
-  dev_url: https://github.com/Thriftpy/thriftpy2/
+  doc_url: https://thriftpy2.readthedocs.io
+  dev_url: https://github.com/Thriftpy/thriftpy2
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
thriftpy2 0.5.3 

**Destination channel:** Defaults

### Links

- [PKG-10656]
- dev_url:        https://github.com/Thriftpy/thriftpy2//tree/v0.5.3
- conda_forge:    https://github.com/conda-forge/thriftpy2-feedstock
- pypi:           https://pypi.org/project/thriftpy2/0.5.3
- pypi inspector: https://inspector.pypi.io/project/thriftpy2/0.5.3

### Explanation of changes:

- new version number


[PKG-10656]: https://anaconda.atlassian.net/browse/PKG-10656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ